### PR TITLE
Adding support form connection params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastaai/basta-js",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.5",
   "description": "A lightweight package for client-side apps to easily access and manage data from Basta's online auctions, providing a seamless integration for creating engaging auction experiences.",
   "author": "Basta (https://www.basta.ai)",
   "homepage": "https://docs.basta.ai",

--- a/src/client/urql-client.ts
+++ b/src/client/urql-client.ts
@@ -25,11 +25,13 @@ export function createUrqlClientWithConfig(
       url: config.wsUrl,
       retryAttempts: Infinity,
       shouldRetry: () => true, // auto-reconnect on disconnect
-      connectionParams: config.wsConnectionParams || (() => {
-        // Default: pass HTTP headers as connection params
-        // This allows auth headers to work for WS connections
-        return config.headers || {};
-      }),
+      connectionParams:
+        config.wsConnectionParams ||
+        (() => {
+          // Default: pass HTTP headers as connection params
+          // This allows auth headers to work for WS connections
+          return config.headers || {};
+        }),
     });
 
     exchanges.push(

--- a/src/client/urql-client.ts
+++ b/src/client/urql-client.ts
@@ -25,6 +25,11 @@ export function createUrqlClientWithConfig(
       url: config.wsUrl,
       retryAttempts: Infinity,
       shouldRetry: () => true, // auto-reconnect on disconnect
+      connectionParams: config.wsConnectionParams || (() => {
+        // Default: pass HTTP headers as connection params
+        // This allows auth headers to work for WS connections
+        return config.headers || {};
+      }),
     });
 
     exchanges.push(

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface ApiConfig {
   url?: string;
   headers?: Record<string, string>;
   wsUrl?: string;
+  wsConnectionParams?: Record<string, unknown> | (() => Record<string, unknown>);
 }
 
 // Type-safe wrapper for GraphqlOperation that preserves the field selection type

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,9 @@ export interface ApiConfig {
   url?: string;
   headers?: Record<string, string>;
   wsUrl?: string;
-  wsConnectionParams?: Record<string, unknown> | (() => Record<string, unknown>);
+  wsConnectionParams?:
+    | Record<string, unknown>
+    | (() => Record<string, unknown>);
 }
 
 // Type-safe wrapper for GraphqlOperation that preserves the field selection type


### PR DESCRIPTION
This pull request introduces improvements to the configuration and connection handling of the URQL client, particularly enhancing WebSocket (WS) support and flexibility in passing connection parameters. The most significant changes involve allowing custom or default connection parameters for WS connections and updating the package version.

**WebSocket connection improvements:**

* Added a new `wsConnectionParams` option to the `ApiConfig` interface, allowing users to specify custom connection parameters for WebSocket connections, or provide a function returning those parameters (`src/types.ts`).
* Updated the `createUrqlClientWithConfig` function to use the new `wsConnectionParams` if provided, or default to passing HTTP headers as connection parameters for WebSocket connections, improving authentication support (`src/client/urql-client.ts`).

**Package maintenance:**

* Bumped the package version from `1.0.0-alpha.3` to `1.0.0-alpha.5` in `package.json` to reflect the new features and improvements.